### PR TITLE
Change mutableList.removeLast() to mutableList.removeLast() due to compileSDK 35 issue

### DIFF
--- a/Sources/SkipLib/Skip/Collections.kt
+++ b/Sources/SkipLib/Skip/Collections.kt
@@ -573,7 +573,9 @@ interface BidirectionalCollection<Element>: Collection<Element>, MutableListStor
 
     fun removeLast(): Element {
         willMutateStorage()
-        val lastElement = mutableList.removeLast().sref()
+        // cannot use removeLast() anymore: https://developer.android.com/about/versions/15/behavior-changes-15#openjdk-api-changes
+        //val lastElement = mutableList.removeLast().sref()
+        val lastElement = mutableList.removeAt(mutableList.lastIndex).sref()
         didMutateStorage()
         return lastElement
     }

--- a/Tests/SkipLibTests/CollectionsTests.swift
+++ b/Tests/SkipLibTests/CollectionsTests.swift
@@ -386,10 +386,14 @@ final class CollectionsTests: XCTestCase {
     }
 
     func testRemoveLast() {
-        var arr1 = [1, 3, 5]
-        XCTAssertEqual(5, arr1.removeLast())
-        XCTAssertEqual(3, arr1.removeLast())
-        XCTAssertEqual([1], arr1)
+        var arr = [1, 3, 5]
+        XCTAssertEqual(5, arr.removeLast())
+        XCTAssertEqual(3, arr.removeLast())
+        XCTAssertEqual([1], arr)
+        XCTAssertEqual(1, arr.popLast())
+        XCTAssertEqual(nil, arr.popLast())
+        XCTAssertEqual(0, arr.count)
+        XCTAssertTrue(arr.isEmpty)
     }
 }
 


### PR DESCRIPTION
Same issue as https://github.com/skiptools/skip-foundation/pull/34

See also:
https://developer.android.com/about/versions/15/behavior-changes-15#openjdk-api-changes
https://youtrack.jetbrains.com/issue/KT-71375/Prevent-Kotlins-removeFirst-and-removeLast-from-causing-crashes-on-Android-14-and-below-after-upgrading-to-Android-API-Level-35
