### PR TITLE
Fix regex replacements containing special characters

### DIFF
--- a/Sources/SkipLib/Regex.swift
+++ b/Sources/SkipLib/Regex.swift
@@ -59,7 +59,8 @@ public struct Regex : RegexComponent {
     }
 
     public func replace(_ string: String, with replacement: String) -> String {
-        return _regex.replace(string, replacement)
+        let safeReplacement = java.util.regex.Matcher.quoteReplacement(replacement)
+        return _regex.replace(string, safeReplacement)
     }
 }
 

--- a/Tests/SkipLibTests/RegexTests.swift
+++ b/Tests/SkipLibTests/RegexTests.swift
@@ -21,6 +21,7 @@ import Testing
         #expect("1z1" == "1x1".replacing(try Regex("[a-z]"), with: "z"))
         #expect("Z1X1" == "!1X1".replacing(try Regex("^[^a-zA-Z0-9]"), with: "Z"))
         #expect("1X1Z" == "1X1!".replacing(try Regex("[^a-zA-Z0-9]$"), with: "Z"))
+        #expect("\\d" == "x".replacing(try Regex("x"), with: "\\d"))
 
         #expect("Hello, Alice!" == "Hello, Bob!".replacing(try Regex("Hello, (\\w+)!"), with: "Hello, Alice!"))
 


### PR DESCRIPTION
`kotlin.text.Regex.replace` interprets `\` as a special character not just in the match string, but also in the replacement string. You have to quote the replacement string with `java.util.regex.Matcher.quoteReplacement`.

I've added a test that passes on this branch and fails on the main branch.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor tracked the bug down and fixed it; I wrote the test and verified that it fails on main and passes on this branch.