### PR TITLE
Add `String.replacing(:maxReplacements:with:)` with a closure

### DIFF
--- a/Sources/SkipLib/Regex.swift
+++ b/Sources/SkipLib/Regex.swift
@@ -61,6 +61,24 @@ public struct Regex : RegexComponent {
     public func replace(_ string: String, with replacement: String) -> String {
         return _regex.replace(string, replacement)
     }
+
+    public func replace(_ string: String, maxReplacements: Int = Int.max, with replacement: (Match) throws -> String) rethrows -> String {
+        if maxReplacements <= 0 {
+            return string
+        }
+
+        var replacementCount = 0
+        return _regex.replace(string) { match in
+            let replacementValue: String
+            if replacementCount < maxReplacements {
+                replacementCount += 1
+                replacementValue = try replacement(Match(match: match))
+            } else {
+                replacementValue = match.value
+            }
+            return java.util.regex.Matcher.quoteReplacement(replacementValue)
+        }
+    }
 }
 
 #endif

--- a/Sources/SkipLib/Skip/String.kt
+++ b/Sources/SkipLib/Skip/String.kt
@@ -437,6 +437,10 @@ fun String.replacing(regex: Regex, with: String): String {
     return regex.replace(this, with)
 }
 
+fun String.replacing(regex: Regex, maxReplacements: Int = Int.max, with: (Regex.Match) -> String): String {
+    return regex.replace(this, maxReplacements = maxReplacements, with = with)
+}
+
 operator fun String.Companion.invoke(format: String, vararg args: Any): String {
     return format.kotlinFormatString.format(*args)
 }

--- a/Sources/SkipLib/String.swift
+++ b/Sources/SkipLib/String.swift
@@ -67,6 +67,10 @@ public struct String: RandomAccessCollection {
     public func replacing(_ regex: Regex, with: String) -> String {
         fatalError()
     }
+
+    public func replacing(_ regex: Regex, maxReplacements: Int = Int.max, with replacement: (Regex.Match) throws -> String) rethrows -> String {
+        fatalError()
+    }
 }
 
 public struct Substring: RandomAccessCollection {

--- a/Tests/SkipLibTests/RegexTests.swift
+++ b/Tests/SkipLibTests/RegexTests.swift
@@ -24,6 +24,10 @@ import Testing
 
         #expect("Hello, Alice!" == "Hello, Bob!".replacing(try Regex("Hello, (\\w+)!"), with: "Hello, Alice!"))
 
+        #expect("1zz1" == "1z1".replacing(try Regex("([a-z])"), with: { match in
+            return match[1].substring! + match[1].substring!
+        }))
+
         #if SKIP
         // skip: regular expression support is incomplete
         return


### PR DESCRIPTION
```swift
#expect("1zz1" == "1z1".replacing(try Regex("([a-z])"), with: { match in
    return match[1].substring! + match[1].substring!
}))
```

This lets you replace a matching groups with dynamic content.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I wrote the test; Cursor wrote the code. (It's not a lot of code.) The test fails on the main branch, and passes here.