### PR TITLE
Support replacing literal strings with literal strings

### DIFF
--- a/Sources/SkipLib/Skip/String.kt
+++ b/Sources/SkipLib/Skip/String.kt
@@ -433,6 +433,10 @@ fun String.matches(of: Regex): Array<Regex.Match> {
     return of.matches(this)
 }
 
+fun String.replacing(other: String, with: String): String {
+    return replace(oldValue = other, newValue = with)
+}
+
 fun String.replacing(regex: Regex, with: String): String {
     return regex.replace(this, with)
 }

--- a/Sources/SkipLib/String.swift
+++ b/Sources/SkipLib/String.swift
@@ -64,6 +64,10 @@ public struct String: RandomAccessCollection {
         fatalError()
     }
 
+    public func replacing(_ other: String, with: String) -> String {
+        fatalError()
+    }
+
     public func replacing(_ regex: Regex, with: String) -> String {
         fatalError()
     }

--- a/Tests/SkipLibTests/RegexTests.swift
+++ b/Tests/SkipLibTests/RegexTests.swift
@@ -13,6 +13,8 @@ import Testing
     }
 
     @Test func regexReplace() throws {
+        #expect("X" == "1".replacing("1", with: "X"))
+        #expect("AX" == "A\\w".replacing("\\w", with: "X"))
         #expect("X" == "1".replacing(try Regex("[0-9]"), with: "X"))
         #expect("XXX" == "1X1".replacing(try Regex("[0-9]"), with: "X"))
         #expect("1Z1" == "1X1".replacing(try Regex("[A-Z]"), with: "Z"))


### PR DESCRIPTION
You _can_ do this with `replacingOccurrences`, but I found it confusing remembering which `replacing` functions are implemented and which ones aren't, so, here's another one.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

