### PR TITLE
Split string by string

### DIFF
--- a/Sources/SkipLib/Skip/String.kt
+++ b/Sources/SkipLib/Skip/String.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 package skip.lib
 
+import java.lang.Character
 import java.util.Random
 
 /// Allow Swift code to reference Substring type.
@@ -248,33 +249,57 @@ fun <RE> String.compactMap(transform: (Char) -> RE?): Array<RE> {
 }
 fun <RE> Substring.compactMap(transform: (Char) -> RE?): Array<RE> = stringValue.compactMap(transform)
 
-fun String.split(separator: Char, maxSplits: Int = Int.max, omittingEmptySubsequences: Boolean = true): Array<String> {
-    if (this.isEmpty()) return if (omittingEmptySubsequences) Array() else Array(listOf(""))
+fun String.split(separator: String, maxSplits: Int = Int.max, omittingEmptySubsequences: Boolean = true): Array<String> {
+    if (!omittingEmptySubsequences) {
+        val limit = if (maxSplits == Int.max) 0 else maxSplits + 1
+        return Array(split(separator, limit = limit))
+    }
+
+    if (separator.isEmpty()) {
+        return splitOnEmptyStringSeparatorIncludingEmptySubsequences(maxSplits)
+    }
 
     val result = mutableListOf<String>()
     var start = 0
     var splits = 0
 
-    for (i in this.indices) {
-        if (this[i] == separator && splits < maxSplits) {
-            val part = this.substring(start, i)
-            if (!omittingEmptySubsequences || part.isNotEmpty()) {
-                result.add(part)
-            }
-            start = i + 1
+    while (splits < maxSplits) {
+        val found = indexOf(separator, start)
+        if (found < 0) break
+        val part = substring(start, found)
+        if (part.isNotEmpty()) {
+            result.add(part)
             splits++
-            if (splits >= maxSplits) { break }
         }
+        start = found + separator.length
     }
-
-    val part = this.substring(start)
-    if (!omittingEmptySubsequences || part.isNotEmpty()) {
-        result.add(part)
+    val rest = substring(start)
+    if (rest.isNotEmpty()) {
+        result.add(rest)
     }
-
     return Array(result, nocopy = true)
 }
-fun Substring.split(separator: Char, maxSplits: Int = Int.max, omittingEmptySubsequences: Boolean = true): Array<String> = stringValue.split(separator = separator, maxSplits = maxSplits, omittingEmptySubsequences = omittingEmptySubsequences)
+
+// Ideally, this would use Kotlin split, but Kotlin split mangles emojis
+private fun String.splitOnEmptyStringSeparatorIncludingEmptySubsequences(maxSplits: Int): Array<String> {
+    val result = mutableListOf<String>()
+    var remainder = this
+    var splits = 0
+    while (splits < maxSplits && remainder.isNotEmpty()) {
+        val cp = Character.codePointAt(remainder, 0)
+        val len = Character.charCount(cp)
+        val first = remainder.substring(0, len)
+        result.add(first)
+        remainder = remainder.substring(len)
+        splits++
+    }
+    if (remainder.isNotEmpty()) {
+        result.add(remainder)
+    }
+    return Array(result, nocopy = true)
+}
+
+fun Substring.split(separator: String, maxSplits: Int = Int.max, omittingEmptySubsequences: Boolean = true): Array<String> = stringValue.split(separator = separator, maxSplits = maxSplits, omittingEmptySubsequences = omittingEmptySubsequences)
 
 fun String.joined(): String = this
 fun Substring.joined(): String = stringValue

--- a/Sources/SkipLib/String.swift
+++ b/Sources/SkipLib/String.swift
@@ -56,7 +56,7 @@ public struct String: RandomAccessCollection {
     }
 
     // Support in String although it is not yet supported in Collection
-    public func split(separator: Character, maxSplits: Int = Int.max, omittingEmptySubsequences: Bool = true) -> [String] {
+    public func split(separator: String, maxSplits: Int = Int.max, omittingEmptySubsequences: Bool = true) -> [String] {
         fatalError()
     }
 
@@ -109,7 +109,7 @@ public struct Substring: RandomAccessCollection {
     }
 
     // Support in String although it is not yet supported in Collection
-    public func split(separator: Character, maxSplits: Int = Int.max, omittingEmptySubsequences: Bool = true) -> [String] {
+    public func split(separator: String, maxSplits: Int = Int.max, omittingEmptySubsequences: Bool = true) -> [String] {
         fatalError()
     }
 }

--- a/Tests/SkipLibTests/StringTests.swift
+++ b/Tests/SkipLibTests/StringTests.swift
@@ -257,6 +257,45 @@ import Testing
         #expect(str2 == "ab++cd++efg++hi")
     }
 
+    @Test func splitByString() {
+        // Round-trip: multi-character separator (Kotlin `indexOf` loop)
+        let joined = "ab++cd++efg++hi"
+        #expect(["ab", "cd", "efg", "hi"] == joined.split(separator: "++"))
+
+        // No match → single component
+        #expect(["hello"] == "hello".split(separator: "++"))
+
+        // Empty subject, default omitting empties
+        #expect(0 == "".split(separator: "::").count)
+
+        // maxSplits with multi-character separator
+        #expect(["a", "b++c"] == "a++b++c".split(separator: "++", maxSplits: 1))
+        #expect(["a++b++c"] == "a++b++c".split(separator: "++", maxSplits: 0))
+
+        // Consecutive separators → empty pieces when not omitted (Kotlin scans non-overlapping occurrences)
+        #expect(["a", "", "b"] == "a::::b".split(separator: "::", omittingEmptySubsequences: false))
+        #expect(["a", "b"] == "a::::b".split(separator: "::", omittingEmptySubsequences: true))
+        #expect(["a"] == "::::a".split(separator: "::", maxSplits: 1, omittingEmptySubsequences: true))
+
+        // Non-overlapping scan (separator does not skip past shared characters)
+        #expect(["bar", "baz"] == "foobarfoobaz".split(separator: "foo"))
+        #expect(["ba"] == "ababa".split(separator: "aba"))
+
+        // Empty separator: Kotlin `splitOnEmptyStringSeparator` (Unicode scalars; matches Swift for ASCII)
+        #expect(["a", "b", "cd"] == "abcd".split(separator: "", maxSplits: 2))
+        #expect(["", "a", "b"] == "ab".split(separator: "", maxSplits: 2, omittingEmptySubsequences: false))
+
+        // Non-ASCII: multi-scalar separator and content (UTF-16 `indexOf` / Kotlin `String.indexOf`)
+        #expect(["你好", "世界", "！"] == "你好++世界++！".split(separator: "++"))
+        #expect(["مرحبا", "بالعالم"] == "مرحبا##بالعالم".split(separator: "##"))
+        #expect(["a", "b", "c"] == "a∑b∑c".split(separator: "∑"))
+
+        // Supplementary-plane scalars (emoji): delimiter and segments are full scalar substrings
+        #expect(["😀", "🎉"] == "😀++🎉".split(separator: "++"))
+        #expect(["a", "b", "c"] == "a🙂b🙂c".split(separator: "🙂"))
+        #expect(["😀", "😀", "😀"] == "😀😀😀".split(separator: "", maxSplits: 2))
+    }
+
     @Test func splitMax() {
         let str = "ab,cd,efg,,hi"
         #expect(["ab,cd,efg,,hi"] == str.split(separator: ",", maxSplits: 0))


### PR DESCRIPTION
This PR may be a bit surprising, because it removes `func split(separator: Character)` and adds in `func split(separator: String)`. To my surprise, even when I left both overloads in, the existing character-based tests were all just using the string version once I added it.

Since the character-based implementation was, as far as I could tell, dead code, I eliminated it.

The implementation tries to use Kotlin [`split()`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.text/split.html) if we're not `omittingEmptySequences`, but `omittingEmptySequences` defaults to true, so a simple `"a,b,c".split(separator: ",")` will not use Kotlin `split()`.

(I also had to implement a whole separate code path for when the separator is empty, to match Swift's behavior in that case.)

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor generated a first draft (especially the tests), and I rewrote its output.

